### PR TITLE
Only check collisions while weapon is swinging

### DIFF
--- a/hammer-and-heart/hammer.gd
+++ b/hammer-and-heart/hammer.gd
@@ -1,4 +1,1 @@
-extends Area3D
-func _physics_process(delta: float) -> void:
-	#set_process(false)
-	pass
+extends Node3D

--- a/hammer-and-heart/hammer.gd.uid
+++ b/hammer-and-heart/hammer.gd.uid
@@ -1,1 +1,1 @@
-uid://bjrc4st6qc3kp
+uid://b80275db38poq

--- a/hammer-and-heart/hammer.tscn
+++ b/hammer-and-heart/hammer.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=3 format=3 uid="uid://blir70542amxk"]
+[gd_scene load_steps=4 format=3 uid="uid://blir70542amxk"]
 
+[ext_resource type="Script" uid="uid://b80275db38poq" path="res://hammer.gd" id="1_7mb5m"]
 [ext_resource type="ArrayMesh" uid="uid://dmwou7q54kmyp" path="res://hammer.obj" id="1_nn80s"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_snr3i"]
@@ -7,6 +8,7 @@ size = Vector3(0.90094, 0.831116, 1.99615)
 
 [node name="Hammer" type="Node3D" groups=["weapon"]]
 transform = Transform3D(0.15, 0, 0, 0, 0.15, 0, 0, 0, 0.15, 0, 0, 0)
+script = ExtResource("1_7mb5m")
 
 [node name="Hammer" type="MeshInstance3D" parent="."]
 mesh = ExtResource("1_nn80s")

--- a/hammer-and-heart/player.gd
+++ b/hammer-and-heart/player.gd
@@ -15,16 +15,17 @@ func _input(event):
 	if event.is_action_pressed("Attack"):
 		attacking = true
 		anim["parameters/playback"].travel("Attack")
-		#$Node/Skeleton3D/WeaponAttachment/Hammer/Hitbox.set_process(true)
+		$Node/Skeleton3D/WeaponAttachment/Hammer/Hitbox.process_mode = Node.PROCESS_MODE_ALWAYS
 		
 	elif direction:
 		anim["parameters/playback"].travel("Walk")
 	else:
 		anim["parameters/playback"].travel("Idle")
 
+func _ready() -> void:
+	$Node/Skeleton3D/WeaponAttachment/Hammer/Hitbox.process_mode = Node.PROCESS_MODE_DISABLED
+	
 func _physics_process(delta: float) -> void:
-	#if not attacking:
-		#$Node/Skeleton3D/WeaponAttachment/Hammer/Hitbox.set_physics_process(false)
 	# Add the gravity.
 	if not is_on_floor():
 		velocity += get_gravity() * delta
@@ -55,5 +56,5 @@ func _on_animation_tree_animation_finished(anim_name: StringName) -> void:
 	#print(anim_name)
 	if anim_name == "Greatswordslash":
 		attacking = false
-		#$Node/Skeleton3D/WeaponAttachment/Hammer/Hitbox.set_process(false)
+		$Node/Skeleton3D/WeaponAttachment/Hammer/Hitbox.process_mode = Node.PROCESS_MODE_DISABLED
 		


### PR DESCRIPTION
Weapon hitbox will be disabled by default and activate only while attack animations are playing.